### PR TITLE
Switched to cursorV2 to make use of the fix for #140

### DIFF
--- a/apps/cli/src/commands/bookmarks.ts
+++ b/apps/cli/src/commands/bookmarks.ts
@@ -123,6 +123,7 @@ bookmarkCmd
       archived: opts.includeArchived ? undefined : false,
       listId: opts.listId,
       limit: MAX_NUM_BOOKMARKS_PER_PAGE,
+      useCursorV2: true,
     };
 
     let resp = await api.bookmarks.getBookmarks.query(request);


### PR DESCRIPTION
realized that the cli is not using cursorV2 and is causing an infite loop/going out of memory if bookmarks created at the same second exist