### PR TITLE
Feature request: Browser extension "Open your Hoarder saves" #188

### DIFF
--- a/apps/browser-extension/manifest.json
+++ b/apps/browser-extension/manifest.json
@@ -11,6 +11,9 @@
   "action": {
     "default_popup": "index.html"
   },
+  "background": {
+    "service_worker": "src/background/background.ts"
+  },
   "options_ui": {
     "page": "index.html#options",
     "open_in_tab": false
@@ -23,5 +26,5 @@
   "content_security_policy": {
     "extension_pages": "script-src 'self'; object-src 'self'"
   },
-  "permissions": ["storage", "tabs"]
+  "permissions": ["storage", "tabs", "contextMenus"]
 }

--- a/apps/browser-extension/src/background/background.ts
+++ b/apps/browser-extension/src/background/background.ts
@@ -1,0 +1,45 @@
+import { Settings } from "../utils/settings.ts";
+
+const OPEN_HOARDER_ID = "open-hoarder";
+
+function checkSettingsState(settings: Settings) {
+  if (settings?.address) {
+    registerContextMenu(settings.address);
+  } else {
+    chrome.contextMenus.remove(OPEN_HOARDER_ID);
+  }
+}
+
+/**
+ * Registers a context menu button to open a tab with the currently configured hoarder instance
+ * @param address The address of the configured hoarder instance
+ */
+function registerContextMenu(address: string) {
+  chrome.contextMenus.create({
+    id: OPEN_HOARDER_ID,
+    title: "Open Hoarder",
+    contexts: ["action"],
+  });
+  chrome.contextMenus.onClicked.addListener(createContextClickHandler(address));
+}
+
+/**
+ *
+ * @param address the address of the hoarder instance
+ * @returns an event handler that will open a tab with the hoarder instance
+ */
+function createContextClickHandler(address: string) {
+  return (info: chrome.contextMenus.OnClickData) => {
+    const { menuItemId } = info;
+    if (menuItemId === OPEN_HOARDER_ID) {
+      chrome.tabs.create({ url: address, active: true });
+    }
+  };
+}
+
+chrome.storage.sync.get("settings", (items) =>
+  checkSettingsState(items.settings as Settings),
+);
+chrome.storage.sync.onChanged.addListener((changes) => {
+  checkSettingsState(changes.settings.newValue as Settings);
+});

--- a/apps/browser-extension/src/utils/settings.ts
+++ b/apps/browser-extension/src/utils/settings.ts
@@ -26,6 +26,9 @@ export function subscribeToSettingsChanges(
   callback: (settings: Settings) => void,
 ) {
   chrome.storage.sync.onChanged.addListener((changes) => {
+    if (changes.settings === undefined) {
+      return;
+    }
     callback(changes.settings.newValue as Settings);
   });
 }

--- a/apps/browser-extension/src/utils/settings.ts
+++ b/apps/browser-extension/src/utils/settings.ts
@@ -21,3 +21,11 @@ export default function usePluginSettings() {
 export async function getPluginSettings() {
   return (await chrome.storage.sync.get("settings")).settings as Settings;
 }
+
+export function subscribeToSettingsChanges(
+  callback: (settings: Settings) => void,
+) {
+  chrome.storage.sync.onChanged.addListener((changes) => {
+    callback(changes.settings.newValue as Settings);
+  });
+}

--- a/apps/browser-extension/tsconfig.json
+++ b/apps/browser-extension/tsconfig.json
@@ -6,6 +6,8 @@
     "module": "ESNext",
     "skipLibCheck": true,
 
+    "types": ["chrome"],
+
     "moduleResolution": "bundler",
     "allowImportingTsExtensions": true,
     "resolveJsonModule": true,


### PR DESCRIPTION
Adds a context menu entry when a hoarder instance is configured and removes it again, if it is not configured anymore