### PR TITLE
Hide archived bookmarks on favourite List

### DIFF
--- a/apps/mobile/app/dashboard/favourites.tsx
+++ b/apps/mobile/app/dashboard/favourites.tsx
@@ -8,6 +8,7 @@ export default function Favourites() {
       <UpdatingBookmarkList
         query={{
           favourited: true,
+          archived: false 
         }}
         header={<PageTitle title="⭐️ Favourites" />}
       />

--- a/apps/web/app/dashboard/favourites/page.tsx
+++ b/apps/web/app/dashboard/favourites/page.tsx
@@ -4,7 +4,7 @@ export default async function FavouritesBookmarkPage() {
   return (
     <Bookmarks
       header={<p className="text-2xl">⭐️ Favourites</p>}
-      query={{ favourited: true }}
+      query={{ favourited: true, archived: false }}
       showDivider={true}
       showEditorCard={true}
     />


### PR DESCRIPTION
## What?
- Updated the favorite list functionality to exclude archived bookmarks.

## Why?
- Improved UX by ensuring that the favorite list only displays active, non-archived bookmarks.
- Maintained consistency with the intended behavior of archiving, where archived assets should only be visible on the dedicated archived page and not in other sections of the application.