### PR TITLE
fix: Remove the bookmark update text limit

### DIFF
--- a/packages/trpc/routers/bookmarks.ts
+++ b/packages/trpc/routers/bookmarks.ts
@@ -334,7 +334,7 @@ export const bookmarksAppRouter = router({
     .input(
       z.object({
         bookmarkId: z.string(),
-        text: z.string().max(2000),
+        text: z.string(),
       }),
     )
     .use(ensureBookmarkOwnership)


### PR DESCRIPTION
I so no use of having a limit in the update only while the create have no such limit.