### PR TITLE
[UI] Landing page Image breaking on safari

### DIFF
--- a/apps/landing/app/page.tsx
+++ b/apps/landing/app/page.tsx
@@ -181,7 +181,7 @@ function Platforms() {
               className="flex items-center justify-center gap-2"
             >
               <Image
-                className="h-12 w-full rounded-md"
+                className="h-12 w-auto rounded-md"
                 alt={platform.name}
                 src={platform.badge}
               />


### PR DESCRIPTION
- Images on landing page are getting stretched on safari
<img width="1341" alt="image" src="https://github.com/hoarder-app/hoarder/assets/45597394/4379cf4a-03b3-4ece-b1a3-1f440a4c225e">