### PR TITLE
fix(web): Add sans-serif fallback for Inter font in CJK character sets

### DIFF
--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -18,7 +18,10 @@ import { ReactQueryDevtools } from "@tanstack/react-query-devtools";
 
 import { clientConfig } from "@hoarder/shared/config";
 
-const inter = Inter({ subsets: ["latin"] });
+const inter = Inter({
+  subsets: ["latin"],
+  fallback: ["sans-serif"],
+});
 
 export const metadata: Metadata = {
   title: "Hoarder",


### PR DESCRIPTION
Thank you for creating such awesome software.

This PR addresses the issue of Inter fonts not loading for CJK (Chinese, Japanese, and Korean) character sets, resulting in an inconsistent appearance. To improve consistency of appearance, a sans-serif fallback is specified. This ensures that if the Inter font fails to load, the generic sans-serif font will be used to maintain a consistent look across different character sets.

Original:
![Screenshot 2024-07-04 at 11-08-18 Hoarder](https://github.com/hoarder-app/hoarder/assets/1730234/926d99a0-380c-48f0-bf63-386048da29be)

This PR:
![Screenshot 2024-07-04 at 11-08-44 Hoarder](https://github.com/hoarder-app/hoarder/assets/1730234/2c4a2a38-44eb-4dee-975f-a7da3ad87f2e)

Input text: "日本語表示確認用サンプル文"