### PR TITLE
Bug: Delete confirmation doesn't disappear after bulk deletion of links using WebUI #290

### DIFF
--- a/apps/web/components/dashboard/BulkBookmarksAction.tsx
+++ b/apps/web/components/dashboard/BulkBookmarksAction.tsx
@@ -83,6 +83,7 @@ export default function BulkBookmarksAction() {
     toast({
       description: `${selectedBookmarks.length} bookmarks have been deleted!`,
     });
+    setIsDeleteDialogOpen(false);
   };
 
   const alreadyFavourited =
@@ -102,7 +103,7 @@ export default function BulkBookmarksAction() {
       hidden: !isBulkEditEnabled,
     },
     {
-      name: alreadyArchived ? "Un-arhcive" : "Archive",
+      name: alreadyArchived ? "Un-archive" : "Archive",
       icon: <ArchivedActionIcon size={18} archived={!!alreadyArchived} />,
       action: () => updateBookmarks({ archived: !alreadyArchived }),
       isPending: updateBookmarkMutator.isPending,


### PR DESCRIPTION
closing delete dialog after deleting the bookmarks