### PR TITLE
fix: trim slash from url for the mobile app

### DIFF
--- a/apps/mobile/app/signin.tsx
+++ b/apps/mobile/app/signin.tsx
@@ -82,7 +82,7 @@ export default function Signin() {
               keyboardType="url"
               onChangeText={(e) => {
                 setServerAddress(e);
-                setSettings({ ...settings, address: e });
+                setSettings({ ...settings, address: e.replace(/\/$/, "") });
               }}
             />
           </View>


### PR DESCRIPTION
Hi, small pull request to fix the removal of the slash at the end of a server address on mobile.

It was mentioned in https://github.com/hoarder-app/hoarder/issues/311 and I used the same code as in the linked code by @MohamedBassem.

Extension:
https://github.com/hoarder-app/hoarder/blob/809a9bc35ad4b975dbd4eacc5c6aa8ab285b6d9a/apps/browser-extension/src/NotConfiguredPage.tsx#L25