### PR TITLE
fix(web): Improve SidebarItem tap target accessibility

### DIFF
--- a/apps/web/components/dashboard/sidebar/AllLists.tsx
+++ b/apps/web/components/dashboard/sidebar/AllLists.tsx
@@ -39,19 +39,19 @@ export default function AllLists({
         logo={<span className="text-lg">📋</span>}
         name="All Lists"
         path={`/dashboard/lists`}
-        className="py-0.5"
+        linkClassName="py-0.5"
       />
       <SidebarItem
         logo={<span className="text-lg">⭐️</span>}
         name="Favourites"
         path={`/dashboard/favourites`}
-        className="py-0.5"
+        linkClassName="py-0.5"
       />
       <SidebarItem
         logo={<span className="text-lg">🗄️</span>}
         name="Archive"
         path={`/dashboard/archive`}
-        className="py-0.5"
+        linkClassName="py-0.5"
       />
 
       {
@@ -86,7 +86,7 @@ export default function AllLists({
                   </Button>
                 </ListOptions>
               }
-              className="group py-0.5"
+              linkClassName="group py-0.5"
               style={{ marginLeft: `${level * 1}rem` }}
             />
           )}

--- a/apps/web/components/dashboard/sidebar/SidebarItem.tsx
+++ b/apps/web/components/dashboard/sidebar/SidebarItem.tsx
@@ -10,6 +10,7 @@ export default function SidebarItem({
   logo,
   path,
   className,
+  linkClassName,
   style,
   collapseButton,
   right = null,
@@ -19,6 +20,7 @@ export default function SidebarItem({
   path: string;
   style?: React.CSSProperties;
   className?: string;
+  linkClassName?: string;
   right?: React.ReactNode;
   collapseButton?: React.ReactNode;
 }) {
@@ -26,20 +28,28 @@ export default function SidebarItem({
   return (
     <li
       className={cn(
-        "relative rounded-lg px-3 py-2 hover:bg-accent",
+        "relative rounded-lg hover:bg-accent",
         path == currentPath ? "bg-accent/50" : "",
         className,
       )}
       style={style}
     >
       {collapseButton}
-      <div className="flex justify-between">
-        <Link href={path} className="flex w-full gap-x-2">
-          {logo}
-          <span className="my-auto"> {name} </span>
-        </Link>
-        {right}
-      </div>
+      <Link
+        href={path}
+        className={cn(
+          "flex w-full items-center rounded-[inherit] px-3 py-2",
+          linkClassName,
+        )}
+      >
+        <div className="flex w-full justify-between">
+          <div className="flex items-center gap-x-2">
+            {logo}
+            <span>{name}</span>
+          </div>
+          {right}
+        </div>
+      </Link>
     </li>
   );
 }


### PR DESCRIPTION
This PR enhances the accessibility and user experience of the SidebarItem component by expanding the clickable area to cover the entire item.

#### Before
![chrome_Jgp0L9nYyq](https://github.com/user-attachments/assets/e2635d58-2c94-4d31-b7f0-5a21480cd4d0)

#### After
![chrome_JsRJSZFLMs](https://github.com/user-attachments/assets/a675782d-d5f7-44fd-aade-763bdedc6118)
