### PR TITLE
[Feature Request] Ability to select what to "crawl full page archive" #398

### DIFF
--- a/apps/web/components/dashboard/BulkBookmarksAction.tsx
+++ b/apps/web/components/dashboard/BulkBookmarksAction.tsx
@@ -10,7 +10,7 @@ import { useToast } from "@/components/ui/use-toast";
 import useBulkActionsStore from "@/lib/bulkActions";
 import {
   CheckCheck,
-  FileArchive,
+  FileDown,
   Hash,
   List,
   Pencil,
@@ -24,6 +24,7 @@ import {
   useRecrawlBookmark,
   useUpdateBookmark,
 } from "@hoarder/shared-react/hooks/bookmarks";
+import { BookmarkTypes } from "@hoarder/shared/types/bookmarks";
 
 import BulkManageListsModal from "./bookmarks/BulkManageListsModal";
 import BulkTagModal from "./bookmarks/BulkTagModal";
@@ -78,18 +79,19 @@ export default function BulkBookmarksAction() {
   }
 
   const recrawlBookmarks = async (archiveFullPage: boolean) => {
+    const links = selectedBookmarks.filter(
+      (item) => item.content.type === BookmarkTypes.LINK,
+    );
     await Promise.all(
-      selectedBookmarks.map((item) =>
+      links.map((item) =>
         recrawlBookmarkMutator.mutateAsync({
           bookmarkId: item.id,
           archiveFullPage,
         }),
       ),
     );
-    let message = `${selectedBookmarks.length} bookmarks will be `;
-    message += archiveFullPage ? "re-crawled and archived!" : "refreshed!";
     toast({
-      description: message,
+      description: `${links.length} bookmarks will be ${archiveFullPage ? "re-crawled and archived!" : "refreshed!"}`,
     });
   };
 
@@ -161,17 +163,17 @@ export default function BulkBookmarksAction() {
       hidden: !isBulkEditEnabled,
     },
     {
-      name: "Crawl Full Page Archive",
-      icon: <FileArchive size={18} />,
+      name: "Download Full Page Archive",
+      icon: <FileDown size={18} />,
       action: () => recrawlBookmarks(true),
-      isPending: false,
+      isPending: recrawlBookmarkMutator.isPending,
       hidden: !isBulkEditEnabled,
     },
     {
       name: "Refresh",
       icon: <RotateCw size={18} />,
       action: () => recrawlBookmarks(false),
-      isPending: false,
+      isPending: recrawlBookmarkMutator.isPending,
       hidden: !isBulkEditEnabled,
     },
     {

--- a/apps/web/components/dashboard/bookmarks/BookmarkOptions.tsx
+++ b/apps/web/components/dashboard/bookmarks/BookmarkOptions.tsx
@@ -11,7 +11,7 @@ import {
 import { useToast } from "@/components/ui/use-toast";
 import { useClientConfig } from "@/lib/clientConfig";
 import {
-  FileArchive,
+  FileDown,
   Link,
   List,
   ListX,
@@ -172,8 +172,8 @@ export default function BookmarkOptions({ bookmark }: { bookmark: ZBookmark }) {
                 });
               }}
             >
-              <FileArchive className="mr-2 size-4" />
-              <span>Crawl Full Page Archive</span>
+              <FileDown className="mr-2 size-4" />
+              <span>Download Full Page Archive</span>
             </DropdownMenuItem>
           )}
 

--- a/apps/web/components/dashboard/bookmarks/BookmarkOptions.tsx
+++ b/apps/web/components/dashboard/bookmarks/BookmarkOptions.tsx
@@ -11,6 +11,7 @@ import {
 import { useToast } from "@/components/ui/use-toast";
 import { useClientConfig } from "@/lib/clientConfig";
 import {
+  FileArchive,
   Link,
   List,
   ListX,
@@ -88,6 +89,15 @@ export default function BookmarkOptions({ bookmark }: { bookmark: ZBookmark }) {
     onError,
   });
 
+  const fullPageArchiveBookmarkMutator = useRecrawlBookmark({
+    onSuccess: () => {
+      toast({
+        description: "Full Page Archive creation has been triggered",
+      });
+    },
+    onError,
+  });
+
   const removeFromListMutator = useRemoveBookmarkFromList({
     onSuccess: () => {
       toast({
@@ -152,6 +162,21 @@ export default function BookmarkOptions({ bookmark }: { bookmark: ZBookmark }) {
             />
             <span>{bookmark.archived ? "Un-archive" : "Archive"}</span>
           </DropdownMenuItem>
+
+          {bookmark.content.type === BookmarkTypes.LINK && (
+            <DropdownMenuItem
+              onClick={() => {
+                fullPageArchiveBookmarkMutator.mutate({
+                  bookmarkId: bookmark.id,
+                  archiveFullPage: true,
+                });
+              }}
+            >
+              <FileArchive className="mr-2 size-4" />
+              <span>Crawl Full Page Archive</span>
+            </DropdownMenuItem>
+          )}
+
           {bookmark.content.type === BookmarkTypes.LINK && (
             <DropdownMenuItem
               onClick={() => {

--- a/apps/workers/crawlerWorker.ts
+++ b/apps/workers/crawlerWorker.ts
@@ -212,7 +212,7 @@ async function getBookmarkDetails(bookmarkId: string) {
   });
 
   if (!bookmark || !bookmark.link) {
-    throw new Error("The bookmark either doesn't exist or not a link");
+    throw new Error("The bookmark either doesn't exist or is not a link");
   }
   return {
     url: bookmark.link.url,
@@ -517,6 +517,7 @@ async function crawlAndParseUrl(
   oldScreenshotAssetId: string | undefined,
   oldImageAssetId: string | undefined,
   oldFullPageArchiveAssetId: string | undefined,
+  archiveFullPage: boolean,
 ) {
   const {
     htmlContent,
@@ -576,7 +577,7 @@ async function crawlAndParseUrl(
   ]);
 
   return async () => {
-    if (serverConfig.crawler.fullPageArchive) {
+    if (serverConfig.crawler.fullPageArchive || archiveFullPage) {
       const fullPageArchiveAssetId = await archiveWebpage(
         htmlContent,
         browserUrl,
@@ -613,7 +614,7 @@ async function runCrawler(job: DequeuedJob<ZCrawlLinkRequest>) {
     return;
   }
 
-  const { bookmarkId } = request.data;
+  const { bookmarkId, archiveFullPage } = request.data;
   const {
     url,
     userId,
@@ -652,6 +653,7 @@ async function runCrawler(job: DequeuedJob<ZCrawlLinkRequest>) {
       oldScreenshotAssetId,
       oldImageAssetId,
       oldFullPageArchiveAssetId,
+      archiveFullPage,
     );
   }
 

--- a/packages/shared/queues.ts
+++ b/packages/shared/queues.ts
@@ -17,8 +17,9 @@ export function runQueueDBMigrations() {
 export const zCrawlLinkRequestSchema = z.object({
   bookmarkId: z.string(),
   runInference: z.boolean().optional(),
+  archiveFullPage: z.boolean().optional().default(false),
 });
-export type ZCrawlLinkRequest = z.infer<typeof zCrawlLinkRequestSchema>;
+export type ZCrawlLinkRequest = z.input<typeof zCrawlLinkRequestSchema>;
 
 export const LinkCrawlerQueue = new SqliteQueue<ZCrawlLinkRequest>(
   "link_crawler_queue",

--- a/packages/trpc/routers/bookmarks.ts
+++ b/packages/trpc/routers/bookmarks.ts
@@ -426,11 +426,17 @@ export const bookmarksAppRouter = router({
       }
     }),
   recrawlBookmark: authedProcedure
-    .input(z.object({ bookmarkId: z.string() }))
+    .input(
+      z.object({
+        bookmarkId: z.string(),
+        archiveFullPage: z.boolean().optional().default(false),
+      }),
+    )
     .use(ensureBookmarkOwnership)
     .mutation(async ({ input }) => {
       await LinkCrawlerQueue.enqueue({
         bookmarkId: input.bookmarkId,
+        archiveFullPage: input.archiveFullPage,
       });
     }),
   getBookmark: authedProcedure


### PR DESCRIPTION
Added the ability to start a full page crawl for links and also in bulk operations
added the ability to refresh links as a bulk operation as well

I have split the PR into 2 parts for now. This one is the easy part and will just allow triggering the full page archive. The next one will deal with the changes required to allow multiple archives to be stored, as we discussed in discord.