### PR TITLE
[Feature request] Force AI to use existing tags (instead of creating them) #111

### DIFF
--- a/apps/web/app/dashboard/settings/prompts/page.tsx
+++ b/apps/web/app/dashboard/settings/prompts/page.tsx
@@ -289,7 +289,7 @@ export function PromptDemo() {
           clientConfig.inference.inferredTagLang,
           (prompts ?? [])
             .filter((p) => p.appliesTo == "text" || p.appliesTo == "all")
-            .map((p) => p.text),
+            .map((p) => p.text.replaceAll("$tags", "[<TAGS_HERE>]")),
           "\n<CONTENT_HERE>\n",
         ).trim()}
       </code>
@@ -299,7 +299,7 @@ export function PromptDemo() {
           clientConfig.inference.inferredTagLang,
           (prompts ?? [])
             .filter((p) => p.appliesTo == "images" || p.appliesTo == "all")
-            .map((p) => p.text),
+            .map((p) => p.text.replaceAll("$tags", "[<TAGS_HERE>]")),
         ).trim()}
       </code>
     </div>


### PR DESCRIPTION
PR for #111
added a $tags placeholder that will be replaced with all existing tags during inference
This allows you to tweak the prompt in a way that it can actually reuse existing tags.

Currently the prompt preview simply shows `[<TAGS_HERE>]` instead of `$tags` (similar to the `<CONTENT_HERE>`), so the UI does not have to load all the tags and to keep the prompt preview small, but if needed, we can actually replace it.