### PR TITLE
Add HEALTHCHECK to Dockerfile

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -102,12 +102,16 @@ RUN touch /etc/s6-overlay/s6-rc.d/user/contents.d/init-db-migration \
     /etc/s6-overlay/s6-rc.d/user/contents.d/svc-web \
     /etc/s6-overlay/s6-rc.d/user/contents.d/svc-workers
 
+HEALTHCHECK --interval=30s --timeout=10s --start-period=5s --retries=3 CMD wget --no-verbose --tries=1 --spider http://127.0.0.1:3000/api/health || exit 1
+
 ################# The web container ##############
 
 FROM aio_builder AS web
 
 RUN touch /etc/s6-overlay/s6-rc.d/user/contents.d/init-db-migration \
     /etc/s6-overlay/s6-rc.d/user/contents.d/svc-web
+
+HEALTHCHECK --interval=30s --timeout=10s --start-period=5s --retries=3 CMD wget --no-verbose --tries=1 --spider http://127.0.0.1:3000/api/health || exit 1
 
 ################# The workers container ##############
 


### PR DESCRIPTION
i added the healthcheck to the AIO and legacy web container. 

checked on my AIO instance:

```
{
   "Status":"healthy",
   "FailingStreak":0,
   "Log":[
      {
         "Start":"2024-10-07T21:23:19.83382568+02:00",
         "End":"2024-10-07T21:23:20.003640388+02:00",
         "ExitCode":0,
         "Output":"Connecting to 127.0.0.1:3000 (127.0.0.1:3000)\nremote file exists\n"
      }
   ]
}
```