### PR TITLE
Add Source Label to Dockerfile

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -32,6 +32,7 @@ RUN (cd apps/cli && pnpm build)
 ################# The All-in-one builder ##############
 
 FROM node:21-alpine AS aio_builder
+LABEL org.opencontainers.image.source="https://github.com/hoarder-app/hoarder"
 WORKDIR /app
 
 ARG SERVER_VERSION=nightly
@@ -121,6 +122,7 @@ RUN rm /etc/s6-overlay/s6-rc.d/svc-workers/dependencies.d/init-db-migration \
 ################# The cli ##############
 
 FROM node:21-alpine AS cli
+LABEL org.opencontainers.image.source="https://github.com/hoarder-app/hoarder"
 WORKDIR /app
 
 COPY --from=base /app/apps/cli/dist/index.mjs apps/cli/index.mjs


### PR DESCRIPTION
To get changelogs shown with Renovate a docker container has to add the source label described in the OCI Image Format Specification.

For reference: https://github.com/renovatebot/renovate/blob/main/lib/modules/datasource/docker/readme.md