### PR TITLE
Add header in layout

### DIFF
--- a/apps/web/app/dashboard/archive/page.tsx
+++ b/apps/web/app/dashboard/archive/page.tsx
@@ -3,13 +3,11 @@ import InfoTooltip from "@/components/ui/info-tooltip";
 
 function header() {
   return (
-    <div className="flex items-center justify-between">
-      <div className="flex gap-2">
-        <p className="text-2xl">🗄️ Archive</p>
-        <InfoTooltip size={17} className="my-auto" variant="explain">
-          <p>Archived bookmarks won&apos;t appear in the homepage</p>
-        </InfoTooltip>
-      </div>
+    <div className="flex gap-2">
+      <p className="text-2xl">🗄️ Archive</p>
+      <InfoTooltip size={17} className="my-auto" variant="explain">
+        <p>Archived bookmarks won&apos;t appear in the homepage</p>
+      </InfoTooltip>
     </div>
   );
 }

--- a/apps/web/app/dashboard/archive/page.tsx
+++ b/apps/web/app/dashboard/archive/page.tsx
@@ -1,5 +1,4 @@
 import Bookmarks from "@/components/dashboard/bookmarks/Bookmarks";
-import GlobalActions from "@/components/dashboard/GlobalActions";
 import InfoTooltip from "@/components/ui/info-tooltip";
 
 function header() {
@@ -10,9 +9,6 @@ function header() {
         <InfoTooltip size={17} className="my-auto" variant="explain">
           <p>Archived bookmarks won&apos;t appear in the homepage</p>
         </InfoTooltip>
-      </div>
-      <div>
-        <GlobalActions />
       </div>
     </div>
   );

--- a/apps/web/app/dashboard/bookmarks/page.tsx
+++ b/apps/web/app/dashboard/bookmarks/page.tsx
@@ -1,18 +1,10 @@
 import React from "react";
 import Bookmarks from "@/components/dashboard/bookmarks/Bookmarks";
-import GlobalActions from "@/components/dashboard/GlobalActions";
-import { SearchInput } from "@/components/dashboard/search/SearchInput";
 
 export default async function BookmarksPage() {
   return (
     <div>
-      <div className="flex gap-2">
-        <SearchInput />
-        <GlobalActions />
-      </div>
-      <div className="my-4">
         <Bookmarks query={{ archived: false }} showEditorCard={true} />
-      </div>
     </div>
   );
 }

--- a/apps/web/app/dashboard/bookmarks/page.tsx
+++ b/apps/web/app/dashboard/bookmarks/page.tsx
@@ -4,7 +4,7 @@ import Bookmarks from "@/components/dashboard/bookmarks/Bookmarks";
 export default async function BookmarksPage() {
   return (
     <div>
-        <Bookmarks query={{ archived: false }} showEditorCard={true} />
+      <Bookmarks query={{ archived: false }} showEditorCard={true} />
     </div>
   );
 }

--- a/apps/web/app/dashboard/favourites/page.tsx
+++ b/apps/web/app/dashboard/favourites/page.tsx
@@ -1,5 +1,4 @@
 import Bookmarks from "@/components/dashboard/bookmarks/Bookmarks";
-import GlobalActions from "@/components/dashboard/GlobalActions";
 
 export default async function FavouritesBookmarkPage() {
   return (
@@ -7,7 +6,6 @@ export default async function FavouritesBookmarkPage() {
       header={
         <div className="flex items-center justify-between">
           <p className="text-2xl">⭐️ Favourites</p>
-          <GlobalActions />
         </div>
       }
       query={{ favourited: true }}

--- a/apps/web/app/dashboard/layout.tsx
+++ b/apps/web/app/dashboard/layout.tsx
@@ -1,9 +1,10 @@
+import Header from "@/components/dashboard/header/Header";
 import MobileSidebar from "@/components/dashboard/sidebar/ModileSidebar";
 import Sidebar from "@/components/dashboard/sidebar/Sidebar";
 import DemoModeBanner from "@/components/DemoModeBanner";
 import { Separator } from "@/components/ui/separator";
 import ValidAccountCheck from "@/components/utils/ValidAccountCheck";
-import Header from "@/components/dashboard/header/Header";
+
 import serverConfig from "@hoarder/shared/config";
 
 export default async function Dashboard({
@@ -28,9 +29,9 @@ export default async function Dashboard({
             <Separator />
           </div>
           {modal}
-          <div className="container min-h-30 p-4">{children}</div>
+          <div className="min-h-30 container p-4">{children}</div>
         </main>
-    </div>
+      </div>
     </div>
   );
 }

--- a/apps/web/app/dashboard/layout.tsx
+++ b/apps/web/app/dashboard/layout.tsx
@@ -3,7 +3,7 @@ import Sidebar from "@/components/dashboard/sidebar/Sidebar";
 import DemoModeBanner from "@/components/DemoModeBanner";
 import { Separator } from "@/components/ui/separator";
 import ValidAccountCheck from "@/components/utils/ValidAccountCheck";
-
+import Header from "@/components/dashboard/header/Header";
 import serverConfig from "@hoarder/shared/config";
 
 export default async function Dashboard({
@@ -14,20 +14,23 @@ export default async function Dashboard({
   modal: React.ReactNode;
 }>) {
   return (
-    <div className="flex min-h-screen w-screen flex-col sm:h-screen sm:flex-row">
-      <ValidAccountCheck />
-      <div className="hidden flex-none sm:flex">
-        <Sidebar />
-      </div>
-      <main className="flex-1 bg-muted sm:overflow-y-auto">
-        {serverConfig.demoMode && <DemoModeBanner />}
-        <div className="block w-full sm:hidden">
-          <MobileSidebar />
-          <Separator />
+    <div>
+      <Header />
+      <div className="flex min-h-[calc(100vh-64px)] w-screen flex-col sm:h-[calc(100vh-64px)] sm:flex-row">
+        <ValidAccountCheck />
+        <div className="hidden flex-none sm:flex">
+          <Sidebar />
         </div>
-        {modal}
-        <div className="container min-h-screen p-4">{children}</div>
-      </main>
+        <main className="flex-1 bg-muted sm:overflow-y-auto">
+          {serverConfig.demoMode && <DemoModeBanner />}
+          <div className="block w-full sm:hidden">
+            <MobileSidebar />
+            <Separator />
+          </div>
+          {modal}
+          <div className="container min-h-30 p-4">{children}</div>
+        </main>
+    </div>
     </div>
   );
 }

--- a/apps/web/app/dashboard/search/page.tsx
+++ b/apps/web/app/dashboard/search/page.tsx
@@ -2,7 +2,6 @@
 
 import { Suspense, useRef } from "react";
 import BookmarksGrid from "@/components/dashboard/bookmarks/BookmarksGrid";
-import GlobalActions from "@/components/dashboard/GlobalActions";
 import { SearchInput } from "@/components/dashboard/search/SearchInput";
 import { FullPageSpinner } from "@/components/ui/full-page-spinner";
 import { useBookmarkSearch } from "@/lib/hooks/bookmark-search";
@@ -15,10 +14,6 @@ function SearchComp() {
 
   return (
     <div className="flex flex-col gap-3">
-      <div className="flex gap-2">
-        <SearchInput ref={inputRef} autoFocus={true} />
-        <GlobalActions />
-      </div>
       {data ? (
         <BookmarksGrid bookmarks={data.bookmarks} />
       ) : (

--- a/apps/web/app/dashboard/search/page.tsx
+++ b/apps/web/app/dashboard/search/page.tsx
@@ -1,16 +1,12 @@
 "use client";
 
-import { Suspense, useRef } from "react";
+import { Suspense } from "react";
 import BookmarksGrid from "@/components/dashboard/bookmarks/BookmarksGrid";
-import { SearchInput } from "@/components/dashboard/search/SearchInput";
 import { FullPageSpinner } from "@/components/ui/full-page-spinner";
 import { useBookmarkSearch } from "@/lib/hooks/bookmark-search";
 
 function SearchComp() {
   const { data } = useBookmarkSearch();
-
-  const inputRef: React.MutableRefObject<HTMLInputElement | null> =
-    useRef<HTMLInputElement | null>(null);
 
   return (
     <div className="flex flex-col gap-3">

--- a/apps/web/components/dashboard/GlobalActions.tsx
+++ b/apps/web/components/dashboard/GlobalActions.tsx
@@ -5,7 +5,7 @@ import ChangeLayout from "@/components/dashboard/ChangeLayout";
 
 export default function GlobalActions() {
   return (
-    <div className="flex min-w-max flex-wrap overflow-hidden rounded-md border bg-background">
+    <div className="flex min-w-max flex-wrap overflow-hidden">
       <ChangeLayout />
       <BulkBookmarksAction />
     </div>

--- a/apps/web/components/dashboard/header/Header.tsx
+++ b/apps/web/components/dashboard/header/Header.tsx
@@ -4,27 +4,67 @@ import { SearchInput } from "@/components/dashboard/search/SearchInput";
 import GlobalActions from "@/components/dashboard/GlobalActions";
 import ProfileOptions from "@/components/dashboard/header/ProfileOptions";
 import HoarderLogo from "@/components/HoarderIcon";
-import { Settings } from "lucide-react";
+import { Settings, Shield } from "lucide-react";
 import { Button } from "@/components/ui/button";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
+import { getServerAuthSession } from "@/server/auth";
+import { redirect } from "next/navigation";
 
-export default function Header() {
+export default async function Header() {
+
+  const session = await getServerAuthSession();
+if (!session) {
+  redirect("/");
+}
+
+const adminItem =
+    session.user.role == "admin"
+      ? [
+          {
+            name: "Admin",
+            icon: <Shield size={18} />,
+            path: "/dashboard/admin",
+          },
+        ]
+      : [];
+
+const headerItems = [
+  ...adminItem,
+  {
+    name: "Settings",
+    icon: <Settings size={18} />,
+    path: "/dashboard/settings",
+  },
+];
+
   return (
-    <header className="sticky h-16 top-0 left-0 right-0 flex items-center justify-between p-4 bg-white shadow z-50">
-      <div className="flex items-center">
-        <Link href={"/dashboard/bookmarks"}>
+    <header className="sticky h-16 top-0 left-0 right-0 flex items-center justify-between p-4 bg-white shadow z-50 overflow-auto">
+      <div className="hidden items-center sm:flex">
+        <Link href={"/dashboard/bookmarks"} className="w-56">
           <HoarderLogo height={20} gap="8px" />
         </Link>
       </div>
-      <div className="flex gap-2 w-[60vw]">
-        <SearchInput />
+      <div className="flex gap-2 w-full">
+        <SearchInput className="min-w-40 bg-muted" />
         <GlobalActions />
       </div>
-      <div className="flex items-center">
-        <Button variant="ghost">
-          <Link href="/dashboard/settings" className="flex items-center">
-            <Settings size={18} />
-          </Link>
-        </Button>
+      <div className="items-center hidden sm:flex">
+        {headerItems.map((item) => (
+          <Tooltip key={item.name} delayDuration={0}>
+            <TooltipTrigger asChild>
+              <Button variant="ghost">
+                <Link href={item.path} className="flex items-center">
+                  {item.icon}
+                </Link>
+              </Button>
+            </TooltipTrigger>
+            <TooltipContent side="bottom">{item.name}</TooltipContent>
+          </Tooltip>
+        ))}
         <ProfileOptions />
       </div>
     </header>

--- a/apps/web/components/dashboard/header/Header.tsx
+++ b/apps/web/components/dashboard/header/Header.tsx
@@ -41,7 +41,7 @@ export default async function Header() {
   ];
 
   return (
-    <header className="sticky left-0 right-0 top-0 z-50 flex h-16 items-center justify-between overflow-auto bg-white p-4 shadow">
+    <header className="sticky left-0 right-0 top-0 z-50 flex h-16 items-center justify-between overflow-x-auto overflow-y-hidden bg-background p-4 shadow">
       <div className="hidden items-center sm:flex">
         <Link href={"/dashboard/bookmarks"} className="w-56">
           <HoarderLogo height={20} gap="8px" />

--- a/apps/web/components/dashboard/header/Header.tsx
+++ b/apps/web/components/dashboard/header/Header.tsx
@@ -1,10 +1,10 @@
 import React from "react";
 import Link from "next/link";
-import { SearchInput } from "@/components/dashboard/search/SearchInput";
+import { redirect } from "next/navigation";
 import GlobalActions from "@/components/dashboard/GlobalActions";
 import ProfileOptions from "@/components/dashboard/header/ProfileOptions";
+import { SearchInput } from "@/components/dashboard/search/SearchInput";
 import HoarderLogo from "@/components/HoarderIcon";
-import { Settings, Shield } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import {
   Tooltip,
@@ -12,16 +12,15 @@ import {
   TooltipTrigger,
 } from "@/components/ui/tooltip";
 import { getServerAuthSession } from "@/server/auth";
-import { redirect } from "next/navigation";
+import { Settings, Shield } from "lucide-react";
 
 export default async function Header() {
-
   const session = await getServerAuthSession();
-if (!session) {
-  redirect("/");
-}
+  if (!session) {
+    redirect("/");
+  }
 
-const adminItem =
+  const adminItem =
     session.user.role == "admin"
       ? [
           {
@@ -32,27 +31,27 @@ const adminItem =
         ]
       : [];
 
-const headerItems = [
-  ...adminItem,
-  {
-    name: "Settings",
-    icon: <Settings size={18} />,
-    path: "/dashboard/settings",
-  },
-];
+  const headerItems = [
+    ...adminItem,
+    {
+      name: "Settings",
+      icon: <Settings size={18} />,
+      path: "/dashboard/settings",
+    },
+  ];
 
   return (
-    <header className="sticky h-16 top-0 left-0 right-0 flex items-center justify-between p-4 bg-white shadow z-50 overflow-auto">
+    <header className="sticky left-0 right-0 top-0 z-50 flex h-16 items-center justify-between overflow-auto bg-white p-4 shadow">
       <div className="hidden items-center sm:flex">
         <Link href={"/dashboard/bookmarks"} className="w-56">
           <HoarderLogo height={20} gap="8px" />
         </Link>
       </div>
-      <div className="flex gap-2 w-full">
+      <div className="flex w-full gap-2">
         <SearchInput className="min-w-40 bg-muted" />
         <GlobalActions />
       </div>
-      <div className="items-center hidden sm:flex">
+      <div className="hidden items-center sm:flex">
         {headerItems.map((item) => (
           <Tooltip key={item.name} delayDuration={0}>
             <TooltipTrigger asChild>

--- a/apps/web/components/dashboard/header/Header.tsx
+++ b/apps/web/components/dashboard/header/Header.tsx
@@ -1,0 +1,32 @@
+import React from "react";
+import Link from "next/link";
+import { SearchInput } from "@/components/dashboard/search/SearchInput";
+import GlobalActions from "@/components/dashboard/GlobalActions";
+import ProfileOptions from "@/components/dashboard/header/ProfileOptions";
+import HoarderLogo from "@/components/HoarderIcon";
+import { Settings } from "lucide-react";
+import { Button } from "@/components/ui/button";
+
+export default function Header() {
+  return (
+    <header className="sticky h-16 top-0 left-0 right-0 flex items-center justify-between p-4 bg-white shadow z-50">
+      <div className="flex items-center">
+        <Link href={"/dashboard/bookmarks"}>
+          <HoarderLogo height={20} gap="8px" />
+        </Link>
+      </div>
+      <div className="flex gap-2 w-[60vw]">
+        <SearchInput />
+        <GlobalActions />
+      </div>
+      <div className="flex items-center">
+        <Button variant="ghost">
+          <Link href="/dashboard/settings" className="flex items-center">
+            <Settings size={18} />
+          </Link>
+        </Button>
+        <ProfileOptions />
+      </div>
+    </header>
+  );
+}

--- a/apps/web/components/dashboard/header/ProfileOptions.tsx
+++ b/apps/web/components/dashboard/header/ProfileOptions.tsx
@@ -2,6 +2,7 @@
 
 import Link from "next/link";
 import { useToggleTheme } from "@/components/theme-provider";
+import { redirect } from "next/navigation";
 import { Button } from "@/components/ui/button";
 import {
   DropdownMenu,
@@ -9,9 +10,10 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
-import { LogOut, Moon, MoreHorizontal, Paintbrush, Sun } from "lucide-react";
+import { LogOut, Moon, Paintbrush, Sun } from "lucide-react";
 import { signOut } from "next-auth/react";
 import { useTheme } from "next-themes";
+import { useSession } from "next-auth/react";
 
 function DarkModeToggle() {
   const { theme } = useTheme();
@@ -35,11 +37,14 @@ function DarkModeToggle() {
 
 export default function SidebarProfileOptions() {
   const toggleTheme = useToggleTheme();
+  const { data: session } = useSession();
+  if (!session) return redirect("/");
+
   return (
     <DropdownMenu>
       <DropdownMenuTrigger asChild>
-        <Button variant="ghost">
-          <MoreHorizontal />
+        <Button className="rounded-full bg-black p-0 aspect-square text-white border-4 border-new-gray-200" variant="ghost">
+          {session.user.name?.charAt(0) ?? "U"}
         </Button>
       </DropdownMenuTrigger>
       <DropdownMenuContent className="w-fit">

--- a/apps/web/components/dashboard/header/ProfileOptions.tsx
+++ b/apps/web/components/dashboard/header/ProfileOptions.tsx
@@ -1,8 +1,8 @@
 "use client";
 
 import Link from "next/link";
-import { useToggleTheme } from "@/components/theme-provider";
 import { redirect } from "next/navigation";
+import { useToggleTheme } from "@/components/theme-provider";
 import { Button } from "@/components/ui/button";
 import {
   DropdownMenu,
@@ -11,9 +11,8 @@ import {
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import { LogOut, Moon, Paintbrush, Sun } from "lucide-react";
-import { signOut } from "next-auth/react";
+import { signOut, useSession } from "next-auth/react";
 import { useTheme } from "next-themes";
-import { useSession } from "next-auth/react";
 
 function DarkModeToggle() {
   const { theme } = useTheme();
@@ -43,7 +42,10 @@ export default function SidebarProfileOptions() {
   return (
     <DropdownMenu>
       <DropdownMenuTrigger asChild>
-        <Button className="rounded-full bg-black p-0 aspect-square text-white border-4 border-new-gray-200" variant="ghost">
+        <Button
+          className="border-new-gray-200 aspect-square rounded-full border-4 bg-black p-0 text-white"
+          variant="ghost"
+        >
           {session.user.name?.charAt(0) ?? "U"}
         </Button>
       </DropdownMenuTrigger>

--- a/apps/web/components/dashboard/lists/ListHeader.tsx
+++ b/apps/web/components/dashboard/lists/ListHeader.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { useRouter } from "next/navigation";
-import GlobalActions from "@/components/dashboard/GlobalActions";
 import { Button } from "@/components/ui/button";
 import { MoreHorizontal } from "lucide-react";
 
@@ -43,7 +42,6 @@ export default function ListHeader({
             <MoreHorizontal />
           </Button>
         </ListOptions>
-        <GlobalActions />
       </div>
     </div>
   );

--- a/apps/web/components/dashboard/sidebar/AllLists.tsx
+++ b/apps/web/components/dashboard/sidebar/AllLists.tsx
@@ -47,12 +47,6 @@ export default function AllLists({
         path={`/dashboard/favourites`}
         linkClassName="py-0.5"
       />
-      <SidebarItem
-        logo={<span className="text-lg">🗄️</span>}
-        name="Archive"
-        path={`/dashboard/archive`}
-        linkClassName="py-0.5"
-      />
 
       {
         <CollapsibleBookmarkLists

--- a/apps/web/components/dashboard/sidebar/ModileSidebar.tsx
+++ b/apps/web/components/dashboard/sidebar/ModileSidebar.tsx
@@ -1,8 +1,8 @@
+import ProfileOptions from "@/components/dashboard/header/ProfileOptions";
 import HoarderLogoIcon from "@/public/icons/logo-icon.svg";
 import { ClipboardList, Search, Settings, Tag } from "lucide-react";
 
 import MobileSidebarItem from "./ModileSidebarItem";
-import ProfileOptions from "@/components/dashboard/header/ProfileOptions";
 
 export default async function MobileSidebar() {
   return (

--- a/apps/web/components/dashboard/sidebar/ModileSidebar.tsx
+++ b/apps/web/components/dashboard/sidebar/ModileSidebar.tsx
@@ -2,7 +2,7 @@ import HoarderLogoIcon from "@/public/icons/logo-icon.svg";
 import { ClipboardList, Search, Settings, Tag } from "lucide-react";
 
 import MobileSidebarItem from "./ModileSidebarItem";
-import SidebarProfileOptions from "./SidebarProfileOptions";
+import ProfileOptions from "@/components/dashboard/header/ProfileOptions";
 
 export default async function MobileSidebar() {
   return (
@@ -16,7 +16,7 @@ export default async function MobileSidebar() {
         <MobileSidebarItem logo={<ClipboardList />} path="/dashboard/lists" />
         <MobileSidebarItem logo={<Tag />} path="/dashboard/tags" />
         <MobileSidebarItem logo={<Settings />} path="/dashboard/settings" />
-        <SidebarProfileOptions />
+        <ProfileOptions />
       </ul>
     </aside>
   );

--- a/apps/web/components/dashboard/sidebar/Sidebar.tsx
+++ b/apps/web/components/dashboard/sidebar/Sidebar.tsx
@@ -2,7 +2,7 @@ import { redirect } from "next/navigation";
 import { Separator } from "@/components/ui/separator";
 import { api } from "@/server/api/client";
 import { getServerAuthSession } from "@/server/auth";
-import { Home, Search, Shield, Tag, Github } from "lucide-react";
+import { Home, Search, Archive, Tag, Github } from "lucide-react";
 
 
 import serverConfig from "@hoarder/shared/config";
@@ -28,17 +28,6 @@ export default async function Sidebar() {
       ]
     : [];
 
-  const adminItem =
-    session.user.role == "admin"
-      ? [
-          {
-            name: "Admin",
-            icon: <Shield size={18} />,
-            path: "/dashboard/admin",
-          },
-        ]
-      : [];
-
   const menu: {
     name: string;
     icon: JSX.Element;
@@ -55,7 +44,11 @@ export default async function Sidebar() {
       icon: <Tag size={18} />,
       path: "/dashboard/tags",
     },
-    ...adminItem,
+    {
+      name: "Archive",
+      icon: <Archive size={18} />,
+      path: "/dashboard/archive",
+    },
   ];
 
   return (

--- a/apps/web/components/dashboard/sidebar/Sidebar.tsx
+++ b/apps/web/components/dashboard/sidebar/Sidebar.tsx
@@ -1,16 +1,14 @@
-import Link from "next/link";
 import { redirect } from "next/navigation";
-import HoarderLogo from "@/components/HoarderIcon";
 import { Separator } from "@/components/ui/separator";
 import { api } from "@/server/api/client";
 import { getServerAuthSession } from "@/server/auth";
-import { Home, Search, Settings, Shield, Tag } from "lucide-react";
+import { Home, Search, Shield, Tag, Github } from "lucide-react";
+
 
 import serverConfig from "@hoarder/shared/config";
 
 import AllLists from "./AllLists";
 import SidebarItem from "./SidebarItem";
-import SidebarProfileOptions from "./SidebarProfileOptions";
 
 export default async function Sidebar() {
   const session = await getServerAuthSession();
@@ -57,20 +55,11 @@ export default async function Sidebar() {
       icon: <Tag size={18} />,
       path: "/dashboard/tags",
     },
-    {
-      name: "Settings",
-      icon: <Settings size={18} />,
-      path: "/dashboard/settings",
-    },
     ...adminItem,
   ];
 
   return (
-    <aside className="flex h-screen w-60 flex-col gap-5 border-r p-4">
-      <Link href={"/dashboard/bookmarks"}>
-        <HoarderLogo height={20} gap="8px" />
-      </Link>
-      <Separator />
+    <aside className="flex h-[calc(100vh-64px)] w-60 flex-col gap-5 border-r p-4 ">
       <div>
         <ul className="space-y-2 text-sm font-medium">
           {menu.map((item) => (
@@ -85,9 +74,8 @@ export default async function Sidebar() {
       </div>
       <Separator />
       <AllLists initialData={lists} />
-      <div className="mt-auto flex justify-between justify-self-end">
-        <div className="my-auto"> {session.user.name} </div>
-        <SidebarProfileOptions />
+      <div className="mt-auto flex items-center border-t pt-2">
+        <Github size={18} /> Hoarder
       </div>
     </aside>
   );

--- a/apps/web/components/dashboard/sidebar/Sidebar.tsx
+++ b/apps/web/components/dashboard/sidebar/Sidebar.tsx
@@ -2,7 +2,7 @@ import { redirect } from "next/navigation";
 import { Separator } from "@/components/ui/separator";
 import { api } from "@/server/api/client";
 import { getServerAuthSession } from "@/server/auth";
-import { Archive, Github, Home, Search, Tag } from "lucide-react";
+import { Archive, Home, Search, Tag } from "lucide-react";
 
 import serverConfig from "@hoarder/shared/config";
 
@@ -67,7 +67,7 @@ export default async function Sidebar() {
       <Separator />
       <AllLists initialData={lists} />
       <div className="mt-auto flex items-center border-t pt-2">
-        <Github size={18} /> Hoarder
+        Hoarder v{serverConfig.serverVersion}
       </div>
     </aside>
   );

--- a/apps/web/components/dashboard/sidebar/Sidebar.tsx
+++ b/apps/web/components/dashboard/sidebar/Sidebar.tsx
@@ -2,8 +2,7 @@ import { redirect } from "next/navigation";
 import { Separator } from "@/components/ui/separator";
 import { api } from "@/server/api/client";
 import { getServerAuthSession } from "@/server/auth";
-import { Home, Search, Archive, Tag, Github } from "lucide-react";
-
+import { Archive, Github, Home, Search, Tag } from "lucide-react";
 
 import serverConfig from "@hoarder/shared/config";
 


### PR DESCRIPTION
Add a global header to the layout with the following updates:
 - Relocate the Search and Bulk Actions from individual pages to the header.
 - Move Settings, Admin and general Settings to the header.

Issues this PR addresses
- #520 

### Desktop

https://github.com/user-attachments/assets/461dee82-358b-4b6a-818c-9ea04ab43d0d

### Mobile

https://github.com/user-attachments/assets/3cf331d1-524e-467b-9026-433391a8a23f
