### PR TITLE
nested Lists do not fit well in browser extension window #535

### DIFF
--- a/apps/browser-extension/src/components/ListsSelector.tsx
+++ b/apps/browser-extension/src/components/ListsSelector.tsx
@@ -67,7 +67,7 @@ export function ListsSelector({ bookmarkId }: { bookmarkId: string }) {
           <ChevronsUpDown className="ml-2 h-4 w-4 shrink-0 opacity-50" />
         </Button>
       </PopoverTrigger>
-      <PopoverContent className="w-[200px] p-0">
+      <PopoverContent className="w-[320px] p-0">
         <Command>
           <CommandInput placeholder="Search Lists ..." />
           <CommandList>

--- a/apps/browser-extension/src/components/TagsSelector.tsx
+++ b/apps/browser-extension/src/components/TagsSelector.tsx
@@ -64,7 +64,7 @@ export function TagsSelector({ bookmarkId }: { bookmarkId: string }) {
           <ChevronsUpDown className="ml-2 h-4 w-4 shrink-0 opacity-50" />
         </Button>
       </PopoverTrigger>
-      <PopoverContent className="w-[200px] p-0">
+      <PopoverContent className="w-[320px] p-0">
         <Command>
           <CommandInput
             value={input}


### PR DESCRIPTION
increased size to have the same size as the input field that triggers it

Looks like this afterwards:
![image](https://github.com/user-attachments/assets/f9957a4d-0b8d-48c8-95c3-b9375029d050)
