### PR TITLE
Add upload button for mobile

### DIFF
--- a/apps/web/app/api/assets/route.ts
+++ b/apps/web/app/api/assets/route.ts
@@ -3,11 +3,8 @@ import { TRPCError } from "@trpc/server";
 
 import type { ZUploadResponse } from "@hoarder/shared/types/uploads";
 import { assets, AssetTypes } from "@hoarder/db/schema";
-import {
-  newAssetId,
-  saveAsset,
-  SUPPORTED_UPLOAD_ASSET_TYPES,
-} from "@hoarder/shared/assetdb";
+import { newAssetId, saveAsset } from "@hoarder/shared/assetdb";
+import { SUPPORTED_UPLOAD_ASSET_TYPES } from "@hoarder/shared/assetTypes";
 import serverConfig from "@hoarder/shared/config";
 
 const MAX_UPLOAD_SIZE_BYTES = serverConfig.maxAssetSizeMb * 1024 * 1024;

--- a/apps/web/components/dashboard/UploadDropzone.tsx
+++ b/apps/web/components/dashboard/UploadDropzone.tsx
@@ -81,11 +81,7 @@ function useUploadAssets({
   };
 }
 
-export default function UploadDropzone({
-  children,
-}: {
-  children: React.ReactNode;
-}) {
+export function useFileUploader() {
   const [numUploading, setNumUploading] = useState(0);
   const [numUploaded, setNumUploaded] = useState(0);
   const uploadAssets = useUploadAssets({
@@ -101,6 +97,23 @@ export default function UploadDropzone({
       return;
     },
   });
+
+  return {
+    numUploading,
+    setNumUploading,
+    numUploaded,
+    setNumUploaded,
+    uploadAssets,
+  };
+}
+
+export default function UploadDropzone({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  const { numUploading, setNumUploading, numUploaded, uploadAssets } =
+    useFileUploader();
 
   const [isDragging, setDragging] = useState(false);
   const onDrop = (acceptedFiles: File[]) => {

--- a/apps/web/components/dashboard/bookmarks/EditorCard.tsx
+++ b/apps/web/components/dashboard/bookmarks/EditorCard.tsx
@@ -20,6 +20,7 @@ import { useForm } from "react-hook-form";
 import { z } from "zod";
 
 import { useCreateBookmarkWithPostHook } from "@hoarder/shared-react/hooks/bookmarks";
+import { SUPPORTED_UPLOAD_ASSET_TYPES } from "@hoarder/shared/assetTypes";
 import { BookmarkTypes } from "@hoarder/shared/types/bookmarks";
 
 import { useFileUploader, useUploadAsset } from "../UploadDropzone";
@@ -254,7 +255,7 @@ export default function EditorCard({ className }: { className?: string }) {
             <input
               type="file"
               ref={uploadFile}
-              accept={["image/*", "application/pdf"].join(",")}
+              accept={Array.from(SUPPORTED_UPLOAD_ASSET_TYPES).join(",")}
               multiple
               hidden
               onChange={(e) => {

--- a/apps/workers/crawlerWorker.ts
+++ b/apps/workers/crawlerWorker.ts
@@ -34,15 +34,17 @@ import {
 } from "@hoarder/db/schema";
 import { DequeuedJob, Runner } from "@hoarder/queue";
 import {
-  ASSET_TYPES,
   deleteAsset,
   getAssetSize,
-  IMAGE_ASSET_TYPES,
   newAssetId,
   saveAsset,
   saveAssetFromFile,
-  SUPPORTED_UPLOAD_ASSET_TYPES,
 } from "@hoarder/shared/assetdb";
+import {
+  ASSET_TYPES,
+  IMAGE_ASSET_TYPES,
+  SUPPORTED_UPLOAD_ASSET_TYPES,
+} from "@hoarder/shared/assetTypes";
 import serverConfig from "@hoarder/shared/config";
 import logger from "@hoarder/shared/logger";
 import {

--- a/packages/shared/assetTypes.ts
+++ b/packages/shared/assetTypes.ts
@@ -1,0 +1,29 @@
+export const enum ASSET_TYPES {
+  IMAGE_JPEG = "image/jpeg",
+  IMAGE_PNG = "image/png",
+  IMAGE_WEBP = "image/webp",
+  APPLICATION_PDF = "application/pdf",
+  TEXT_HTML = "text/html",
+}
+
+export const IMAGE_ASSET_TYPES: Set<string> = new Set<string>([
+  ASSET_TYPES.IMAGE_JPEG,
+  ASSET_TYPES.IMAGE_PNG,
+  ASSET_TYPES.IMAGE_WEBP,
+]);
+
+export const FILE_ASSET_TYPES: Set<string> = new Set<string>([
+  ASSET_TYPES.APPLICATION_PDF,
+]);
+
+// The assets that we allow the users to upload
+export const SUPPORTED_UPLOAD_ASSET_TYPES: Set<string> = new Set<string>([
+  ...IMAGE_ASSET_TYPES,
+  ...FILE_ASSET_TYPES,
+]);
+
+// The assets that we support saving in the asset db
+export const SUPPORTED_ASSET_TYPES: Set<string> = new Set<string>([
+  ...SUPPORTED_UPLOAD_ASSET_TYPES,
+  ASSET_TYPES.TEXT_HTML,
+]);

--- a/packages/shared/assetdb.ts
+++ b/packages/shared/assetdb.ts
@@ -3,35 +3,10 @@ import * as path from "path";
 import { Glob } from "glob";
 import { z } from "zod";
 
+import { SUPPORTED_ASSET_TYPES } from "./assetTypes";
 import serverConfig from "./config";
 
 const ROOT_PATH = path.join(serverConfig.dataDir, "assets");
-
-export const enum ASSET_TYPES {
-  IMAGE_JPEG = "image/jpeg",
-  IMAGE_PNG = "image/png",
-  IMAGE_WEBP = "image/webp",
-  APPLICATION_PDF = "application/pdf",
-  TEXT_HTML = "text/html",
-}
-
-export const IMAGE_ASSET_TYPES: Set<string> = new Set<string>([
-  ASSET_TYPES.IMAGE_JPEG,
-  ASSET_TYPES.IMAGE_PNG,
-  ASSET_TYPES.IMAGE_WEBP,
-]);
-
-// The assets that we allow the users to upload
-export const SUPPORTED_UPLOAD_ASSET_TYPES: Set<string> = new Set<string>([
-  ...IMAGE_ASSET_TYPES,
-  ASSET_TYPES.APPLICATION_PDF,
-]);
-
-// The assets that we support saving in the asset db
-export const SUPPORTED_ASSET_TYPES: Set<string> = new Set<string>([
-  ...SUPPORTED_UPLOAD_ASSET_TYPES,
-  ASSET_TYPES.TEXT_HTML,
-]);
 
 function getAssetDir(userId: string, assetId: string) {
   return path.join(ROOT_PATH, userId, assetId);


### PR DESCRIPTION
Add a button next to "Save" button to upload files as drag and drop on mobile is not possible.
I know a native app exists but I prefer the PWA, so I'm adding this button and the share option (in another pull request) because it was missing.

![image](https://github.com/user-attachments/assets/c6d194b3-4935-4595-a452-f32c0cf740a3)
