### PR TITLE
Update 10-import.md

### DIFF
--- a/docs/versioned_docs/version-v0.18.0/10-import.md
+++ b/docs/versioned_docs/version-v0.18.0/10-import.md
@@ -36,6 +36,19 @@ If you can get your bookmarks in a text file with one link per line, you can use
 cat all_links.txt | xargs -I{} hoarder --api-key <key> --server-addr <addr> bookmarks add --link {}
 ```
 
+alternatively if you get the error (xargs: command line cannot be assembled, too long), this means your URL is to long. Following bash script can be used to import a file that contains the URLs
+
+```
+#!/bin/bash
+
+api_key="<key>"
+server_addr="<addr>"
+
+while IFS= read -r url; do
+    hoarder --api-key "$api_key" --server-addr "$server_addr" bookmarks add --link "$url"
+done < all_links.txt
+```
+
 ## Exporting Bookmarks from Chrome
 
 - Open Chrome and go to `chrome://bookmarks`


### PR DESCRIPTION
Importing through a bash script, necessary in case the errror "xargs: command line cannot be assembled, too long" occurs. Only tested on Mac, but should work on all environments