### PR TITLE
Custom fetch wrapper

### DIFF
--- a/docker/docker-compose.dev.yml
+++ b/docker/docker-compose.dev.yml
@@ -37,6 +37,8 @@ services:
     volumes:
       - data:/data
       - ..:/app
+    env_file:
+      - .env
     working_dir: /app
     environment:
       MEILI_ADDR: http://meilisearch:7700
@@ -52,6 +54,8 @@ services:
   prep:
     build:
       dockerfile: Dockerfile.dev
+    env_file:
+      - .env
     working_dir: /app
     environment:
       DATA_DIR: /data

--- a/packages/shared/config.ts
+++ b/packages/shared/config.ts
@@ -22,6 +22,7 @@ const allEnv = z.object({
   OLLAMA_BASE_URL: z.string().url().optional(),
   OLLAMA_KEEP_ALIVE: z.string().optional(),
   INFERENCE_JOB_TIMEOUT_SEC: z.coerce.number().default(30),
+  INFERENCE_FETCH_TIMEOUT_SEC: z.coerce.number().default(300),
   INFERENCE_TEXT_MODEL: z.string().default("gpt-4o-mini"),
   INFERENCE_IMAGE_MODEL: z.string().default("gpt-4o-mini"),
   INFERENCE_CONTEXT_LENGTH: z.coerce.number().default(2048),
@@ -80,6 +81,7 @@ const serverConfigSchema = allEnv.transform((val) => {
     },
     inference: {
       jobTimeoutSec: val.INFERENCE_JOB_TIMEOUT_SEC,
+      fetchTimeoutSec: val.INFERENCE_FETCH_TIMEOUT_SEC,
       openAIApiKey: val.OPENAI_API_KEY,
       openAIBaseUrl: val.OPENAI_BASE_URL,
       ollamaBaseUrl: val.OLLAMA_BASE_URL,

--- a/packages/shared/customFetch.ts
+++ b/packages/shared/customFetch.ts
@@ -1,0 +1,11 @@
+import { Agent } from "undici";
+import serverConfig from "./config";
+
+// Custom fetch function with configurable timeout
+export const customFetch = (input: RequestInfo, init: RequestInit = {}) => {
+  const timeout = serverConfig.inference.fetchTimeoutSec * 1000; // Convert to milliseconds
+  return fetch(input, {
+    ...init,
+    dispatcher: new Agent({ headersTimeout: timeout }),
+  });
+};

--- a/packages/shared/inference.ts
+++ b/packages/shared/inference.ts
@@ -3,6 +3,7 @@ import OpenAI from "openai";
 
 import serverConfig from "./config";
 import logger from "./logger";
+import { customFetch } from "./customFetch";
 
 export interface InferenceResponse {
   response: string;
@@ -111,6 +112,7 @@ class OllamaInferenceClient implements InferenceClient {
   constructor() {
     this.ollama = new Ollama({
       host: serverConfig.inference.ollamaBaseUrl,
+      fetch: customFetch, // Use the custom fetch with configurable timeout
     });
   }
 


### PR DESCRIPTION
I added a custom wrapper for fetch to control the `headersTimeout` value. The default value is 5 minutes, and slower instances of ollama can take longer than that, so the fetch fails. The following environment variable allows you to up it (the default is still 5 min).

```yaml
services:
  web:
    environment:
      - INFERENCE_FETCH_TIMEOUT_SEC=3600  # 1 hour fetch timeout
```

There's more info on this in [issue 628](https://github.com/hoarder-app/hoarder/issues/628). I built this locally and tested it against my ollama instance. With the default timeout:

```sh
Nov 14 02:35:33 llama ollama[3733]: [GIN] 2024/11/14 - 02:35:33 | 200 |          5m0s |        10.0.0.2 | POST     "/api/chat"
```

Hard stop at 5 min. The inference job fails.

```sh
workers-1      | 2024-11-14T02:35:33.346Z error: [inference][10] inference job failed: TypeError: fetch failed
workers-1      | TypeError: fetch failed
workers-1      |     at node:internal/deps/undici/undici:13392:13
workers-1      |     at async post (/app/node_modules/ollama/dist/shared/ollama.9c897541.cjs:114:20)
workers-1      |     at async Ollama.processStreamableRequest (/app/node_modules/ollama/dist/shared/ollama.9c897541.cjs:232:25)
workers-1      |     at async OllamaInferenceClient.runModel (/app/packages/shared/inference.ts:2:3386)
workers-1      |     at async OllamaInferenceClient.inferFromText (/app/packages/shared/inference.ts:2:4136)
workers-1      |     at async inferTagsFromText (/app/apps/workers/openaiWorker.ts:6:3135)
workers-1      |     at async inferTags (/app/apps/workers/openaiWorker.ts:6:3370)
workers-1      |     at async Object.runOpenAI [as run] (/app/apps/workers/openaiWorker.ts:6:6863)
workers-1      |     at async Runner.runOnce (/app/node_modules/liteque/dist/runner.js:2:2578)
```

Here is the same job after upping the fetch timeout.

```sh
Nov 14 02:52:23 llama ollama[3733]: [GIN] 2024/11/14 - 02:52:23 | 200 |         7m31s |        10.0.0.2 | POST     "/api/chat"
```

```sh
workers-1      | 2024-11-14T02:55:55.614Z info: [search][13] Completed successfully
```

---

One other small tweak: The docker-compose.dev.yml file needed the env file declared under the worker service.

---

Thanks for making this useful app.