### PR TITLE
Trim whitespace from email on signin page

### DIFF
--- a/apps/mobile/app/signin.tsx
+++ b/apps/mobile/app/signin.tsx
@@ -121,7 +121,7 @@ export default function Signin() {
                   placeholder="Email"
                   keyboardType="email-address"
                   autoCapitalize="none"
-                  value={usernameFormData.email}
+                  value={usernameFormData.email.trim()}
                   onChangeText={(e) =>
                     setUserNameFormData((s) => ({ ...s, email: e }))
                   }

--- a/apps/web/components/signin/CredentialsForm.tsx
+++ b/apps/web/components/signin/CredentialsForm.tsx
@@ -65,7 +65,7 @@ function SignIn() {
         onSubmit={form.handleSubmit(async (value) => {
           const resp = await signIn("credentials", {
             redirect: false,
-            email: value.email,
+            email: value.email.trim(),
             password: value.password,
           });
           if (!resp || !resp?.ok) {
@@ -146,7 +146,7 @@ function SignUp() {
           }
           const resp = await signIn("credentials", {
             redirect: false,
-            email: value.email,
+            email: value.email.trim(),
             password: value.password,
           });
           if (!resp || !resp.ok) {


### PR DESCRIPTION
Sometimes when pasting or using a password manager, an extra space is inserted after an email address. I noticed this caused a sign in failure.

Whitespace isn't valid here, so it's safe to just trim this off.