### PR TITLE
Fix broken link in Debian/Ubuntu install doc

### DIFF
--- a/docs/docs/02-Installation/06-debuntu.md
+++ b/docs/docs/02-Installation/06-debuntu.md
@@ -1,7 +1,7 @@
 # Debian 12/Ubuntu 24.04
 
 :::warning
-This script is a stripped-down version of those found in the [Proxmox Community Scripts](https://github.com/community-scripts/PromoxVE) repo. It has been adapted to work on baremetal Debian 12 or Ubuntu 24.04 installs **only**. Any other use is not supported and you use this script at your own risk.
+This script is a stripped-down version of those found in the [Proxmox Community Scripts](https://github.com/community-scripts/ProxmoxVE) repo. It has been adapted to work on baremetal Debian 12 or Ubuntu 24.04 installs **only**. Any other use is not supported and you use this script at your own risk.
 :::
 
 ### Requirements

--- a/docs/versioned_docs/version-v0.20.0/02-Installation/06-debuntu.md
+++ b/docs/versioned_docs/version-v0.20.0/02-Installation/06-debuntu.md
@@ -1,7 +1,7 @@
 # Debian 12/Ubuntu 24.04
 
 :::warning
-This script is a stripped-down version of those found in the [Proxmox Community Scripts](https://github.com/community-scripts/PromoxVE) repo. It has been adapted to work on baremetal Debian 12 or Ubuntu 24.04 installs **only**. Any other use is not supported and you use this script at your own risk.
+This script is a stripped-down version of those found in the [Proxmox Community Scripts](https://github.com/community-scripts/ProxmoxVE) repo. It has been adapted to work on baremetal Debian 12 or Ubuntu 24.04 installs **only**. Any other use is not supported and you use this script at your own risk.
 :::
 
 ### Requirements


### PR DESCRIPTION
Unfortunately I missed this mistake back when it was added.