### PR TITLE
docs: Add Telegram Bot to community projects

### DIFF
--- a/docs/docs/12-community-projects.md
+++ b/docs/docs/12-community-projects.md
@@ -22,3 +22,11 @@ Get it [here](https://www.raycast.com/luolei/hoarder).
 An Alfred workflow to quickly hoard stuff or access your hoarded bookmarks!
 
 Get it [here](https://www.alfredforum.com/topic/22528-hoarder-workflow-for-self-hosted-bookmark-management/).
+
+### Telegram Bot
+
+*By [@Madh93](https://github.com/Madh93)*
+
+A Telegram Bot for saving bookmarks to Hoarder directly through Telegram.
+
+Get it [here](https://github.com/Madh93/hoarderbot).

--- a/docs/versioned_docs/version-v0.20.0/12-community-projects.md
+++ b/docs/versioned_docs/version-v0.20.0/12-community-projects.md
@@ -22,3 +22,11 @@ Get it [here](https://www.raycast.com/luolei/hoarder).
 An Alfred workflow to quickly hoard stuff or access your hoarded bookmarks!
 
 Get it [here](https://www.alfredforum.com/topic/22528-hoarder-workflow-for-self-hosted-bookmark-management/).
+
+### Telegram Bot
+
+*By [@Madh93](https://github.com/Madh93)*
+
+A Telegram Bot for saving bookmarks to Hoarder directly through Telegram.
+
+Get it [here](https://github.com/Madh93/hoarderbot).


### PR DESCRIPTION
Following the publication of the API, I recently created a [Telegram Bot](https://github.com/Madh93/hoarderbot) that allows users to save bookmarks to Hoarder directly through Telegram.

I've had the habit of adding my bookmarks in Telegram for years, and with this bot, I can continue using that workflow while also benefiting from the automatic tags generated by Hoarder :smile: 