### PR TITLE
feat: show createdAt year in card footer when created over a year ago

### DIFF
--- a/apps/web/components/dashboard/bookmarks/BookmarkLayoutAdaptingCard.tsx
+++ b/apps/web/components/dashboard/bookmarks/BookmarkLayoutAdaptingCard.tsx
@@ -30,6 +30,13 @@ interface Props {
   wrapTags: boolean;
 }
 
+function BookmarkFormattedCreatedAt({ bookmark }: { bookmark: ZBookmark }) {
+  const createdAt = dayjs(bookmark.createdAt);
+  const oneYearAgo = dayjs().subtract(1, "year");
+  const formatString = createdAt.isAfter(oneYearAgo) ? "MMM D" : "MMM D, YYYY";
+  return createdAt.format(formatString);
+}
+
 function BottomRow({
   footer,
   bookmark,
@@ -45,7 +52,7 @@ function BottomRow({
           href={`/dashboard/preview/${bookmark.id}`}
           suppressHydrationWarning
         >
-          {dayjs(bookmark.createdAt).format("MMM DD")}
+          <BookmarkFormattedCreatedAt bookmark={bookmark} />
         </Link>
       </div>
       <BookmarkActionBar bookmark={bookmark} />
@@ -232,7 +239,7 @@ function CompactView({ bookmark, title, footer, className }: Props) {
             suppressHydrationWarning
             className="shrink-0 gap-2 text-gray-500"
           >
-            {dayjs(bookmark.createdAt).format("MMM DD")}
+            <BookmarkFormattedCreatedAt bookmark={bookmark} />
           </Link>
         </div>
         <BookmarkActionBar bookmark={bookmark} />


### PR DESCRIPTION
I imported a bunch of old saves from Pocket and found it hard to tell how old the saves were when browsing

I added the year to the Bookmark Card footer date format string when the bookmark is created over a year ago. It doesn't take up too much space, hope nobody minds the few characters

Happy to move code around or take another stab at this. Thanks!

<details>
<summary>screenshots showing grid and compact bookmark cards</summary>
<img alt="grid preview" src="https://github.com/user-attachments/assets/2612a285-70ca-4ddb-8031-bb158015ff2a" /><br><img alt="compact preview" src="https://github.com/user-attachments/assets/2adde6fc-c66b-407b-8bc9-f72f858310cf" />
</details>