### PR TITLE
Fix openAI pricing link

### DIFF
--- a/docs/docs/06-openai.md
+++ b/docs/docs/06-openai.md
@@ -4,7 +4,7 @@ This service uses OpenAI for automatic tagging. This means that you'll incur som
 
 ## Text Tagging
 
-For text tagging, we use the `gpt-4o-mini` model. This model is [extremely cheap](https://openai.com/pricing). Cost per inference varies depending on the content size per article. Though, roughly, You'll be able to generate tags for almost 3000+ bookmarks for less than $1.
+For text tagging, we use the `gpt-4o-mini` model. This model is [extremely cheap](https://openai.com/api/pricing). Cost per inference varies depending on the content size per article. Though, roughly, You'll be able to generate tags for almost 3000+ bookmarks for less than $1.
 
 ## Image Tagging
 

--- a/docs/versioned_docs/version-v0.20.0/06-openai.md
+++ b/docs/versioned_docs/version-v0.20.0/06-openai.md
@@ -4,7 +4,7 @@ This service uses OpenAI for automatic tagging. This means that you'll incur som
 
 ## Text Tagging
 
-For text tagging, we use the `gpt-4o-mini` model. This model is [extremely cheap](https://openai.com/pricing). Cost per inference varies depending on the content size per article. Though, roughly, You'll be able to generate tags for almost 3000+ bookmarks for less than $1.
+For text tagging, we use the `gpt-4o-mini` model. This model is [extremely cheap](https://openai.com/api/pricing). Cost per inference varies depending on the content size per article. Though, roughly, You'll be able to generate tags for almost 3000+ bookmarks for less than $1.
 
 ## Image Tagging
 

--- a/docs/versioned_docs/version-v0.20.0/06-openai.md
+++ b/docs/versioned_docs/version-v0.20.0/06-openai.md
@@ -4,7 +4,7 @@ This service uses OpenAI for automatic tagging. This means that you'll incur som
 
 ## Text Tagging
 
-For text tagging, we use the `gpt-4o-mini` model. This model is [extremely cheap](https://openai.com/api/pricing). Cost per inference varies depending on the content size per article. Though, roughly, You'll be able to generate tags for almost 3000+ bookmarks for less than $1.
+For text tagging, we use the `gpt-4o-mini` model. This model is [extremely cheap](https://openai.com/pricing). Cost per inference varies depending on the content size per article. Though, roughly, You'll be able to generate tags for almost 3000+ bookmarks for less than $1.
 
 ## Image Tagging
 


### PR DESCRIPTION
This link currently redirects to the ChatGPT subscription-based pricing page, I've updated it with the URL for the model pricing page.