### PR TITLE
feat: Add title option for adding bookmarks from the CLI

### DIFF
--- a/apps/cli/src/commands/bookmarks.ts
+++ b/apps/cli/src/commands/bookmarks.ts
@@ -73,6 +73,7 @@ bookmarkCmd
     collect<string>,
     [],
   )
+  .option("--title <title>", "if set, this will be used as the bookmark's title")
   .action(async (opts) => {
     const api = getAPIClient();
 
@@ -81,7 +82,7 @@ bookmarkCmd
     const promises = [
       ...opts.link.map((url) =>
         api.bookmarks.createBookmark
-          .mutate({ type: BookmarkTypes.LINK, url })
+          .mutate({ type: BookmarkTypes.LINK, url, title: opts.title })
           .then((bookmark: ZBookmark) => {
             results.push(normalizeBookmark(bookmark));
           })
@@ -89,7 +90,7 @@ bookmarkCmd
       ),
       ...opts.note.map((text) =>
         api.bookmarks.createBookmark
-          .mutate({ type: BookmarkTypes.TEXT, text })
+          .mutate({ type: BookmarkTypes.TEXT, text, title: opts.title })
           .then((bookmark: ZBookmark) => {
             results.push(normalizeBookmark(bookmark));
           })
@@ -105,7 +106,7 @@ bookmarkCmd
       const text = fs.readFileSync(0, "utf-8");
       promises.push(
         api.bookmarks.createBookmark
-          .mutate({ type: BookmarkTypes.TEXT, text })
+          .mutate({ type: BookmarkTypes.TEXT, text, title: opts.title })
           .then((bookmark: ZBookmark) => {
             results.push(normalizeBookmark(bookmark));
           })


### PR DESCRIPTION
**Summary:**
This merge request introduces a title option to the bookmark add CLI command, allowing users to specify a title for a link(s) at the time of bookmark creation.

**Details:**
Previously, users had to update a bookmark after creation to set a title, which added an unnecessary step. By including a `--title` option in the bookmark add command, this enhancement streamlines the workflow and improves user experience.