### PR TITLE
Fix context menu handling to prioritize link URLs and include anchor text as bookmark titles

### DIFF
--- a/apps/browser-extension/src/background/background.ts
+++ b/apps/browser-extension/src/background/background.ts
@@ -56,7 +56,13 @@ async function handleContextMenuClick(info: chrome.contextMenus.OnClickData) {
     });
   } else if (menuItemId === ADD_LINK_TO_HOARDER_ID) {
     let newBookmark: ZNewBookmarkRequest | null = null;
-    if (info.selectionText) {
+    if (info.linkUrl) {
+      newBookmark = {
+        type: BookmarkTypes.LINK,
+        url: info.linkUrl,
+        title: info.selectionText ?? undefined,
+      };
+    } else if (info.selectionText) {
       newBookmark = {
         type: BookmarkTypes.TEXT,
         text: info.selectionText,


### PR DESCRIPTION
**Problem:** When users select anchor text and click "Add to Hoarder," the extension was capturing the selected text instead of the link URL. As a result, only the selected text was saved in Hoarder.

![issue](https://github.com/user-attachments/assets/17314a5c-f174-49fe-93f8-02bf2979e9d1)


**Solution:** **Modified `handleContextMenuClick` in `background.ts`:**
  - Prioritized `info.linkUrl` over `info.selectionText` when determining what to hoard.
  - Captured the selected anchor text as the `title` when saving a link bookmark.

![solution](https://github.com/user-attachments/assets/ca5dd51a-9b94-4195-bb96-2bef888d824a)
