### PR TITLE
Fix unsync-similar-dependencies error

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -47,7 +47,7 @@
     "@radix-ui/react-tooltip": "^1.0.7",
     "@svgr/webpack": "^8.1.0",
     "@tanstack/react-query": "^5.24.8",
-    "@tanstack/react-query-devtools": "^5.21.0",
+    "@tanstack/react-query-devtools": "^5.24.8",
     "@trpc/client": "11.0.0-next-beta.308",
     "@trpc/react-query": "11.0.0-next-beta.308",
     "@trpc/server": "11.0.0-next-beta.308",


### PR DESCRIPTION
Running `pnpm i` or `pnpm lint:ws` fails with
```
../.. postinstall:  ⨯ error Similar Tanstack Query dependencies should use the same version. unsync-similar-dependencies
../.. postinstall:   │ {
../.. postinstall:   │   "dependencies": {
../.. postinstall:   ~      "@tanstack/react-query": "^5.24.8",
../.. postinstall:   ~      "@tanstack/react-query-devtools": "^5.21.0"
../.. postinstall:   │   }
../.. postinstall:   │ }
```
This is a sherif rule that just got added
https://newreleases.io/project/npm/sherif/release/1.2.0
and the lint is using using sherif@latest so it got picked up automatically.

Discovered when running the proxmox install script https://github.com/community-scripts/ProxmoxVE/issues/1786
but installing using the [install script](https://docs.hoarder.app/Installation/debuntu) is also affected. This also affects existing releases. Should probably pin sherif to avoid that.