### PR TITLE
fix: add header class name corresponding to dark mode for text color

### DIFF
--- a/apps/mobile/app/dashboard/_layout.tsx
+++ b/apps/mobile/app/dashboard/_layout.tsx
@@ -40,6 +40,7 @@ export default function Dashboard() {
   return (
     <StyledStack
       contentClassName="bg-gray-100 dark:bg-background"
+      headerClassName="dark:text-white"
       screenOptions={{
         headerTransparent: true,
       }}


### PR DESCRIPTION
## Why

The color for the navigation back button and navigation title in dark mode is not adapted and therefore cannot be differentiated from the dark background. Below, I'm sharing some before after screenshots to make the issue more easier to grasp.

## Before

![Screenshot_2025-02-09-18-51-45-05_f73b71075b1de7323614b647fe394240](https://github.com/user-attachments/assets/f3013d2d-b1e7-4f0f-8561-85eebb92911b)

![Screenshot_2025-02-09-18-51-20-87_f73b71075b1de7323614b647fe394240](https://github.com/user-attachments/assets/9a4f249b-e695-40a2-a413-6a9dc89365c5)

## After

![Screenshot_2025-02-09-19-00-21-56_f73b71075b1de7323614b647fe394240](https://github.com/user-attachments/assets/d2996e1b-3916-49b2-81f6-6eee3008303b)

![Screenshot_2025-02-09-19-00-09-30_f73b71075b1de7323614b647fe394240](https://github.com/user-attachments/assets/8aa36c77-7ad9-457a-956a-a33f800df934)


This PR attempts at fixing the bug: https://github.com/hoarder-app/hoarder/issues/829