### PR TITLE
Add Unsorted tab to dashboard

### DIFF
--- a/apps/web/app/dashboard/layout.tsx
+++ b/apps/web/app/dashboard/layout.tsx
@@ -7,7 +7,7 @@ import { Separator } from "@/components/ui/separator";
 import { api } from "@/server/api/client";
 import { getServerAuthSession } from "@/server/auth";
 import { TFunction } from "i18next";
-import { Archive, Highlighter, Home, Search, Tag } from "lucide-react";
+import { Archive, Highlighter, Home, Inbox, Search, Tag } from "lucide-react";
 
 import serverConfig from "@hoarder/shared/config";
 
@@ -55,6 +55,11 @@ export default async function Dashboard({
         name: t("common.archive"),
         icon: <Archive size={18} />,
         path: "/dashboard/archive",
+      },
+      {
+        name: t("common.unsorted"),
+        icon: <Inbox size={18} />,
+        path: "/dashboard/unsorted",
       },
     ].flat();
 

--- a/apps/web/app/dashboard/unsorted/page.tsx
+++ b/apps/web/app/dashboard/unsorted/page.tsx
@@ -1,0 +1,20 @@
+import Bookmarks from "@/components/dashboard/bookmarks/Bookmarks";
+
+function header() {
+  return (
+    <div className="flex gap-2">
+      <p className="text-2xl">📂 Unsorted</p>
+    </div>
+  );
+}
+
+export default async function UnsortedBookmarkPage() {
+  return (
+    <Bookmarks
+      header={header()}
+      query={{ list: null }}
+      showDivider={true}
+      showEditorCard={true}
+    />
+  );
+}


### PR DESCRIPTION
Add a new 'Unsorted' tab to the dashboard to include all items not associated with a list.

* **Dashboard Layout**:
  - Import `Inbox` icon from `lucide-react`.
  - Add 'Unsorted' tab to the `items` function with the `Inbox` icon and path `/dashboard/unsorted`.

* **Unsorted Page**:
  - Create `apps/web/app/dashboard/unsorted/page.tsx`.
  - Import and use the `Bookmarks` component to display items not associated with any list.
  - Set the `query` prop to filter items not associated with any list.
  - Add a header with the title 'Unsorted'.

