### PR TITLE
Adds summarize action to the public API (proxy to TRPC mutation)

### DIFF
--- a/apps/web/app/api/v1/bookmarks/[bookmarkId]/summarize/route.ts
+++ b/apps/web/app/api/v1/bookmarks/[bookmarkId]/summarize/route.ts
@@ -1,0 +1,19 @@
+import { NextRequest } from "next/server";
+import { buildHandler } from "@/app/api/v1/utils/handler";
+
+export const dynamic = "force-dynamic";
+
+export const POST = (
+  req: NextRequest,
+  params: { params: { bookmarkId: string } },
+) =>
+  buildHandler({
+    req,
+    handler: async ({ api }) => {
+      const bookmark = await api.bookmarks.summarizeBookmark({
+        bookmarkId: params.params.bookmarkId,
+      });
+
+      return { status: 200, resp: bookmark };
+    },
+  });

--- a/packages/open-api/hoarder-openapi-spec.json
+++ b/packages/open-api/hoarder-openapi-spec.json
@@ -913,6 +913,85 @@
         }
       }
     },
+    "/bookmarks/{bookmarkId}/summarize": {
+      "post": {
+        "description": "Attaches a summary to the bookmark and returns the updated record.",
+        "summary": "Summarize a bookmark",
+        "tags": [
+          "Bookmarks"
+        ],
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/BookmarkId"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The updated bookmark with summary",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "id": {
+                      "type": "string"
+                    },
+                    "createdAt": {
+                      "type": "string"
+                    },
+                    "modifiedAt": {
+                      "type": "string",
+                      "nullable": true
+                    },
+                    "title": {
+                      "type": "string",
+                      "nullable": true,
+                      "maxLength": 250
+                    },
+                    "archived": {
+                      "type": "boolean"
+                    },
+                    "favourited": {
+                      "type": "boolean"
+                    },
+                    "taggingStatus": {
+                      "type": "string",
+                      "nullable": true,
+                      "enum": [
+                        "success",
+                        "failure",
+                        "pending"
+                      ]
+                    },
+                    "note": {
+                      "type": "string",
+                      "nullable": true
+                    },
+                    "summary": {
+                      "type": "string",
+                      "nullable": true
+                    }
+                  },
+                  "required": [
+                    "id",
+                    "createdAt",
+                    "modifiedAt",
+                    "archived",
+                    "favourited",
+                    "taggingStatus"
+                  ]
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/bookmarks/{bookmarkId}/tags": {
       "post": {
         "description": "Attach tags to a bookmark",

--- a/packages/open-api/lib/bookmarks.ts
+++ b/packages/open-api/lib/bookmarks.ts
@@ -199,6 +199,29 @@ registry.registerPath({
 
 registry.registerPath({
   method: "post",
+  path: "/bookmarks/{bookmarkId}/summarize",
+  description:
+    "Attaches a summary to the bookmark and returns the updated record.",
+  summary: "Summarize a bookmark",
+  tags: ["Bookmarks"],
+  security: [{ [BearerAuth.name]: [] }],
+  request: {
+    params: z.object({ bookmarkId: BookmarkIdSchema }),
+  },
+  responses: {
+    200: {
+      description: "The updated bookmark with summary",
+      content: {
+        "application/json": {
+          schema: zBareBookmarkSchema,
+        },
+      },
+    },
+  },
+});
+
+registry.registerPath({
+  method: "post",
   path: "/bookmarks/{bookmarkId}/tags",
   description: "Attach tags to a bookmark",
   summary: "Attach tags to a bookmark",


### PR DESCRIPTION
I added this in two commits. One is just for me. I had a few issues getting this running locally on a Linux box. It could just be a me problem :|

The second commit has the addition of a subroute for the summary mutation. It should return the bookmark object with the summarized contents. Please feel free to add or remove any commits and I'll do my best to address any feedback.

Thanks for a fantastic project.

Addresses: https://github.com/hoarder-app/hoarder/issues/523