### PR TITLE
fix(workers): Small typo fix in assetPreprocessingWorker.ts

### DIFF
--- a/apps/workers/assetPreprocessingWorker.ts
+++ b/apps/workers/assetPreprocessingWorker.ts
@@ -296,13 +296,13 @@ async function run(req: DequeuedJob<AssetPreprocessingRequest>) {
   let anythingChanged = false;
   switch (bookmark.asset.assetType) {
     case "image": {
-      const extarctedText = await extractAndSaveImageText(
+      const extractedText = await extractAndSaveImageText(
         jobId,
         asset,
         bookmark,
         isFixMode,
       );
-      anythingChanged ||= extarctedText;
+      anythingChanged ||= extractedText;
       break;
     }
     case "pdf": {


### PR DESCRIPTION
I haven't tested if the typos broke anything, but might as well fix now before v0.23.0.

Was introduced by [bbed0ad](https://github.com/hoarder-app/hoarder/commit/bbed0adac4267b2deb14a5b50a4a9844f6e5cafe)