### PR TITLE
feat(auth): Added env variable for OAuth timeout

### DIFF
--- a/apps/web/server/auth.ts
+++ b/apps/web/server/auth.ts
@@ -114,6 +114,9 @@ if (oauth.wellKnownUrl) {
     allowDangerousEmailAccountLinking: oauth.allowDangerousEmailAccountLinking,
     idToken: true,
     checks: ["pkce", "state"],
+    httpOptions: {
+      timeout: oauth.timeout,
+    },
     async profile(profile: Record<string, string>) {
       const [admin, firstUser] = await Promise.all([
         isAdmin(profile.email),

--- a/docs/docs/03-configuration.md
+++ b/docs/docs/03-configuration.md
@@ -35,6 +35,7 @@ When setting up OAuth, the allowed redirect URLs configured at the provider shou
 | OAUTH_SCOPE                                 | No       | "openid email profile" | "Full list of scopes to request (space delimited)"                                                                                                                  |
 | OAUTH_PROVIDER_NAME                         | No       | "Custom Provider"      | The name of your provider. Will be shown on the signup page as "Sign in with `<name>`"                                                                              |
 | OAUTH_ALLOW_DANGEROUS_EMAIL_ACCOUNT_LINKING | No       | false                  | Whether existing accounts in hoarder stored in the database should automatically be linked with your OAuth account. Only enable it if you trust the OAuth provider! |
+| OAUTH_TIMEOUT                               | No       | 3500                   | The wait time in milliseconds for the OAuth provider response. Increase this if you are having `outgoing request timed out` errors |
 
 For more information on `OAUTH_ALLOW_DANGEROUS_EMAIL_ACCOUNT_LINKING`, check the [next-auth.js documentation](https://next-auth.js.org/configuration/providers/oauth#allowdangerousemailaccountlinking-option).
 

--- a/packages/shared/config.ts
+++ b/packages/shared/config.ts
@@ -15,7 +15,7 @@ const allEnv = z.object({
   OAUTH_WELLKNOWN_URL: z.string().url().optional(),
   OAUTH_CLIENT_SECRET: z.string().optional(),
   OAUTH_CLIENT_ID: z.string().optional(),
-  OAUTH_TIMEOUT: z.number().optional().default(3500),
+  OAUTH_TIMEOUT: z.coerce.number().optional().default(3500),
   OAUTH_SCOPE: z.string().default("openid email profile"),
   OAUTH_PROVIDER_NAME: z.string().default("Custom Provider"),
   OPENAI_API_KEY: z.string().optional(),

--- a/packages/shared/config.ts
+++ b/packages/shared/config.ts
@@ -15,6 +15,7 @@ const allEnv = z.object({
   OAUTH_WELLKNOWN_URL: z.string().url().optional(),
   OAUTH_CLIENT_SECRET: z.string().optional(),
   OAUTH_CLIENT_ID: z.string().optional(),
+  OAUTH_TIMEOUT: z.number().optional().default(3500),
   OAUTH_SCOPE: z.string().default("openid email profile"),
   OAUTH_PROVIDER_NAME: z.string().default("Custom Provider"),
   OPENAI_API_KEY: z.string().optional(),
@@ -86,6 +87,7 @@ const serverConfigSchema = allEnv.transform((val) => {
         clientId: val.OAUTH_CLIENT_ID,
         scope: val.OAUTH_SCOPE,
         name: val.OAUTH_PROVIDER_NAME,
+        timeout: val.OAUTH_TIMEOUT,
       },
     },
     inference: {


### PR DESCRIPTION
Small change to add a new env variables for OAuth timeouts, on some configurations, particularly on lower-end hardware (Such as my homelab orange pi), the authentication provider can take too much time to respond, with results in a timeout and failed authentication

The same behavior has been reported over at Homarr, which uses next-auth as well: https://github.com/ajnart/homarr/issues/1995

(My homelab is an orangepi zero3, the auth provider is Authentik)

