### PR TITLE
Close browser if connect on demand

### DIFF
--- a/apps/workers/crawlerWorker.ts
+++ b/apps/workers/crawlerWorker.ts
@@ -350,6 +350,9 @@ async function crawlPage(
     };
   } finally {
     await context.close();
+    if (serverConfig.crawler.browserConnectOnDemand) {
+      await browser.close();
+    }
   }
 }
 


### PR DESCRIPTION
Fix #869 

Close the browser instance after crawling if browserConnectOnDemand is enabled. 
This should help users that are using service like browserless to reduce API usage. 