### PR TITLE
docs: Fixed missing semicolon in update admin password section

### DIFF
--- a/docs/docs/11-FAQ.md
+++ b/docs/docs/11-FAQ.md
@@ -28,7 +28,9 @@ To reset the password:
 * Connect to the `db.db` database, which is located in the `data` directory you have mounted to your docker container:
   * by e.g. running `sqlite3 db.db` (in your `data` directory)
   * or going through e.g. the `dbeaver` UI to locate the file in the data directory and connecting to it
-* Update the password in the database by running `update user set password='$2a$10$5u40XUq/cD/TmLdCOyZ82ePENE6hpkbodJhsp7.e/BgZssUO5DDTa' where email='<YOUR_EMAIL_HERE>'` (don't forget to put your email address into the command)
+* Update the password in the database by running:
+  * `update user set password='$2a$10$5u40XUq/cD/TmLdCOyZ82ePENE6hpkbodJhsp7.e/BgZssUO5DDTa' where email='<YOUR_EMAIL_HERE>';`
+  * (don't forget to put your email address into the command)
 * The new password for your user is now `adminadmin`.
 * Start hoarder again
 * Log in with your email address and the password `adminadmin` and change the password to whatever you want in the `User Settings`


### PR DESCRIPTION
Thanks for the great app and helpful FAQ entry! I'm by no means a database user but needed to change the password and didn't get it to work initially. Figured it our pretty quickly by myself but might be helpful to other people, too. I took the liberty to slightly adjust the formatting as well so that the command fits in one line but feel free to change as you like. Thanks!