### PR TITLE
Link to Github release page in web sidebar

### DIFF
--- a/apps/web/components/shared/sidebar/Sidebar.tsx
+++ b/apps/web/components/shared/sidebar/Sidebar.tsx
@@ -35,7 +35,7 @@ export default async function Sidebar({
         href={`https://github.com/hoarder-app/hoarder/releases/tag/v${serverConfig.serverVersion}`}
         target="_blank"
         rel="noopener noreferrer"
-        className="mt-auto flex items-center border-t pt-2 text-sm text-gray-400"
+        className="mt-auto flex items-center border-t pt-2 text-sm text-gray-400 hover:underline"
       >
         Hoarder v{serverConfig.serverVersion}
       </Link>

--- a/apps/web/components/shared/sidebar/Sidebar.tsx
+++ b/apps/web/components/shared/sidebar/Sidebar.tsx
@@ -33,6 +33,8 @@ export default async function Sidebar({
       {extraSections}
       <Link
         href={`https://github.com/hoarder-app/hoarder/releases/tag/v${serverConfig.serverVersion}`}
+        target="_blank"
+        rel="noopener noreferrer"
         className="mt-auto flex items-center border-t pt-2 text-sm text-gray-400"
       >
         Hoarder v{serverConfig.serverVersion}

--- a/apps/web/components/shared/sidebar/Sidebar.tsx
+++ b/apps/web/components/shared/sidebar/Sidebar.tsx
@@ -1,3 +1,4 @@
+import Link from "next/link";
 import { useTranslation } from "@/lib/i18n/server";
 import { TFunction } from "i18next";
 
@@ -30,9 +31,12 @@ export default async function Sidebar({
         </ul>
       </div>
       {extraSections}
-      <div className="mt-auto flex items-center border-t pt-2 text-sm text-gray-400">
+      <Link
+        href={`https://github.com/hoarder-app/hoarder/releases/tag/v${serverConfig.serverVersion}`}
+        className="mt-auto flex items-center border-t pt-2 text-sm text-gray-400"
+      >
         Hoarder v{serverConfig.serverVersion}
-      </div>
+      </Link>
     </aside>
   );
 }


### PR DESCRIPTION
Hoarder displays information about it's version in the sidebar. This PR adds an improvement that turns this text into a link to Github release page.


https://github.com/user-attachments/assets/9249978d-b667-43b0-9bf6-8821b24880c7

