### PR TITLE
Enable Ukrainian language

### DIFF
--- a/packages/shared/langs.ts
+++ b/packages/shared/langs.ts
@@ -20,6 +20,7 @@ export const langNameMappings: Record<string, string> = {
   es: "Spanish",
   sv: "Swedish",
   tr: "Turkish",
+  uk: "Ukrainian",
   vi: "Vietnamese",
 };
 


### PR DESCRIPTION
As I see in the codebase, Hoarder has already been translated to Ukrainian: https://github.com/hoarder-app/hoarder/blob/main/apps/web/lib/i18n/locales/uk/translation.json

But it's not possible to select Ukrainian language from the UI.