### PR TITLE
ui(web): Clicking view original now opens in a blank tab

### DIFF
--- a/apps/web/components/dashboard/preview/BookmarkPreview.tsx
+++ b/apps/web/components/dashboard/preview/BookmarkPreview.tsx
@@ -120,6 +120,7 @@ export default function BookmarkPreview({
           {sourceUrl && (
             <Link
               href={sourceUrl}
+              target="_blank"
               className="flex items-center gap-2 text-gray-400"
             >
               <span>{t("preview.view_original")}</span>


### PR DESCRIPTION
Fix #1114 
Added target="_blank" attribute to the Link tag.
Now on clicking view original in bookmark details opens in a new tab.